### PR TITLE
Adds a header component for categories

### DIFF
--- a/cypress/integration/userCanChooseUILanguage.feature.js
+++ b/cypress/integration/userCanChooseUILanguage.feature.js
@@ -23,7 +23,10 @@ describe("Internationalization - UI language", () => {
     });
     it("is expected to render the UI in English", () => {
       cy.get("@language").should("have.been.calledOnce");
-      cy.get("[data-cy=category-list]").should("contain.text", "Categories");
+      cy.get("[data-cy=language-selector]").should(
+        "contain.text",
+        "Choose Language"
+      );
     });
 
     it("is expected to switch to Swedish when Swedish is manually selected", () => {
@@ -32,7 +35,7 @@ describe("Internationalization - UI language", () => {
         .within(() => {
           cy.contains("Swedish").click();
         });
-      cy.get("[data-cy=category-list]").should("contain.text", "Sektioner");
+      cy.get("[data-cy=language-selector]").should("contain.text", "Svenska");
     });
   });
 
@@ -48,7 +51,10 @@ describe("Internationalization - UI language", () => {
     });
     it("is expected to render the UI in Swedish", () => {
       cy.get("@language").should("have.been.calledOnce");
-      cy.get("[data-cy=category-list]").should("contain.text", "Sektioner");
+      cy.get("[data-cy=language-selector]").should(
+        "contain.text",
+        "Välj Språk"
+      );
     });
 
     it("is expected to switch to English when English is manually selected", () => {
@@ -59,7 +65,7 @@ describe("Internationalization - UI language", () => {
         .within(() => {
           cy.contains("Engelska").click();
         });
-      cy.get("[data-cy=category-list]").should("contain.text", "Categories");
+      cy.get("[data-cy=language-selector]").should("contain.text", "English");
     });
   });
 });

--- a/cypress/integration/userSeesDifferentCategoryMenus.feature.js
+++ b/cypress/integration/userSeesDifferentCategoryMenus.feature.js
@@ -11,6 +11,7 @@ describe("The Categories render differently on mobile and desktop", () => {
     
     it("is expected that the user sees a dropdown menu with the news categories listed", () => {
       cy.viewport("iphone-x");
+      debugger
       cy.get("[data-cy=mobile-categories-list]").should('be.visible')
     });
   });

--- a/cypress/integration/userSeesDifferentCategoryMenus.feature.js
+++ b/cypress/integration/userSeesDifferentCategoryMenus.feature.js
@@ -1,0 +1,22 @@
+describe("The Categories render differently on mobile and desktop", () => {
+  beforeEach(() => {
+    cy.intercept("GET", "**api/articles", {
+      fixture: "indexRespondsFromApi.json",
+      statusCode: 200,
+    });
+    cy.visit("/");
+  });
+
+  describe("when the user is on mobile", () => {
+    
+    it("is expected that the user sees a dropdown menu with the news categories listed", () => {
+      cy.viewport("iphone-x");
+      cy.get("[data-cy=mobile-categories-list]").should('be.visible')
+    });
+  });
+  describe("when the user is on a desktop", () => {
+    it("is expected that the user sees a subheader with the news categories listed", () => {
+      cy.get("[data-cy=desktop-categories-list]").should('be.visible')
+    });
+  });
+});

--- a/cypress/integration/userSeesDifferentCategoryMenus.feature.js
+++ b/cypress/integration/userSeesDifferentCategoryMenus.feature.js
@@ -8,16 +8,14 @@ describe("The Categories render differently on mobile and desktop", () => {
   });
 
   describe("when the user is on mobile", () => {
-    
     it("is expected that the user sees a dropdown menu with the news categories listed", () => {
       cy.viewport("iphone-x");
-      debugger
-      cy.get("[data-cy=mobile-categories-list]").should('be.visible')
+      cy.get("[data-cy=mobile-category-list]",  {timeout: 5000}).should('be.visible')
     });
   });
   describe("when the user is on a desktop", () => {
     it("is expected that the user sees a subheader with the news categories listed", () => {
-      cy.get("[data-cy=desktop-categories-list]").should('be.visible')
+      cy.get("[data-cy=category-list]").should('be.visible')
     });
   });
 });

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "i18next": "^21.3.2",
     "lodash": "^4.17.21",
     "react": "^17.0.2",
-    "react-device-detect": "^2.1.1",
     "react-dom": "^17.0.2",
     "react-i18next": "^11.12.0",
     "react-redux": "^7.2.5",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "i18next": "^21.3.2",
     "lodash": "^4.17.21",
     "react": "^17.0.2",
+    "react-device-detect": "^2.1.1",
     "react-dom": "^17.0.2",
     "react-i18next": "^11.12.0",
     "react-redux": "^7.2.5",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "react-dom": "^17.0.2",
     "react-i18next": "^11.12.0",
     "react-redux": "^7.2.5",
+    "react-responsive": "^9.0.0-beta.4",
     "react-router-dom": "^5.3.0",
     "react-scripts": "4.0.3",
     "redux": "^4.1.1",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { Switch, Route, BrowserRouter } from "react-router-dom";
-import { isBrowser, isMobile } from "react-device-detect";
 import Header from "./components/Header";
 import Footer from "./components/Footer";
 import HomePage from "./components/HomePage";
@@ -13,11 +12,11 @@ const App = () => {
   if (navigator.language.includes("sv")) {
     i18n.changeLanguage("sv");
   }
-  debugger
+  debugger;
   return (
     <BrowserRouter>
       <Header />
-      {isBrowser && <div>You are a browser!</div>}
+      {/* {isBrowser && <div>You are a browser!</div>} */}
       <Switch>
         <Route exact path="/" component={HomePage}></Route>
         <Route
@@ -25,13 +24,7 @@ const App = () => {
           path={"/articles/:id"}
           component={IndividualArticle}
         ></Route>
-        {isMobile && (
-          <Route
-            exact
-            path={"/category/:category"}
-            component={Category}
-          ></Route>
-        )}
+        <Route exact path={"/category/:category"} component={Category}></Route>
       </Switch>
       <Footer />
     </BrowserRouter>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Switch, Route, BrowserRouter } from "react-router-dom";
+import { isBrowser, isMobile } from "react-device-detect";
 import Header from "./components/Header";
 import Footer from "./components/Footer";
 import HomePage from "./components/HomePage";
@@ -12,11 +13,11 @@ const App = () => {
   if (navigator.language.includes("sv")) {
     i18n.changeLanguage("sv");
   }
-
+  debugger
   return (
     <BrowserRouter>
       <Header />
-      <CategoryHeader />
+      {isBrowser && <div>You are a browser!</div>}
       <Switch>
         <Route exact path="/" component={HomePage}></Route>
         <Route
@@ -24,7 +25,13 @@ const App = () => {
           path={"/articles/:id"}
           component={IndividualArticle}
         ></Route>
-        <Route exact path={"/category/:category"} component={Category}></Route>
+        {isMobile && (
+          <Route
+            exact
+            path={"/category/:category"}
+            component={Category}
+          ></Route>
+        )}
       </Switch>
       <Footer />
     </BrowserRouter>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Switch, Route, BrowserRouter } from "react-router-dom";
+import { useMediaQuery } from "react-responsive";
 import Header from "./components/Header";
 import Footer from "./components/Footer";
 import HomePage from "./components/HomePage";
@@ -9,14 +10,16 @@ import IndividualArticle from "./components/IndividualArticle";
 import i18n from "./i18n";
 
 const App = () => {
+  const isTabletOrMobile = useMediaQuery({ query: "(max-width: 500px)" });
+
   if (navigator.language.includes("sv")) {
     i18n.changeLanguage("sv");
   }
-  debugger;
+
   return (
     <BrowserRouter>
       <Header />
-      {/* {isBrowser && <div>You are a browser!</div>} */}
+      {!isTabletOrMobile && <CategoryHeader />}
       <Switch>
         <Route exact path="/" component={HomePage}></Route>
         <Route

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,6 +4,7 @@ import Header from "./components/Header";
 import Footer from "./components/Footer";
 import HomePage from "./components/HomePage";
 import Category from "./components/Category";
+import CategoryHeader from "./components/CategoryHeader";
 import IndividualArticle from "./components/IndividualArticle";
 import i18n from "./i18n";
 
@@ -15,6 +16,7 @@ const App = () => {
   return (
     <BrowserRouter>
       <Header />
+      <CategoryHeader />
       <Switch>
         <Route exact path="/" component={HomePage}></Route>
         <Route

--- a/src/components/CategoryHeader.jsx
+++ b/src/components/CategoryHeader.jsx
@@ -2,10 +2,12 @@ import React, { useState } from "react";
 import { useSelector } from "react-redux";
 import { Link } from "react-router-dom";
 import { Menu } from "semantic-ui-react";
+import { useTranslation } from "react-i18next";
 
 const CategoryHeader = () => {
   const { categories } = useSelector((state) => state);
   const [activeItem, setActiveItem] = useState("business");
+  const { t } = useTranslation();
 
   let categoriesList = categories.map((category, index) => {
     let categoryToLowerCase = category.toLowerCase();
@@ -26,6 +28,7 @@ const CategoryHeader = () => {
 
   return (
     <Menu pointing secondary data-cy="category-list">
+      <Menu.Item header>{t("categories")}</Menu.Item>
       {categoriesList}
     </Menu>
   );

--- a/src/components/CategoryHeader.jsx
+++ b/src/components/CategoryHeader.jsx
@@ -2,12 +2,10 @@ import React, { useState } from "react";
 import { useSelector } from "react-redux";
 import { Link } from "react-router-dom";
 import { Menu } from "semantic-ui-react";
-import { useTranslation } from "react-i18next";
 
 const CategoryHeader = () => {
   const { categories } = useSelector((state) => state);
   const [activeItem, setActiveItem] = useState("business");
-  const { t } = useTranslation();
 
   let categoriesList = categories.map((category, index) => {
     let categoryToLowerCase = category.toLowerCase();

--- a/src/components/CategoryHeader.jsx
+++ b/src/components/CategoryHeader.jsx
@@ -1,10 +1,35 @@
-import React from 'react'
+import React, { useState } from 'react'
+import { useSelector } from "react-redux";
+import { Link } from "react-router-dom";
+import { Menu } from 'semantic-ui-react'
+
 
 const CategoryHeader = () => {
+  const { categories } = useSelector((state) => state);
+  const [activeItem, setActiveItem] = useState('business')
+
+  let categoriesList = categories.map((category, index) => {
+    let categoryToLowerCase = category.toLowerCase();
+    return (
+      <Menu.Item
+        // data-cy={`${categoryToLowerCase}-category`}
+        name={categoryToLowerCase}
+        as={Link}
+        to={{ pathname: `/category/${categoryToLowerCase}` }}
+        key={index}
+        active={activeItem === categoryToLowerCase}
+        onClick={() => setActiveItem(categoryToLowerCase)}
+      >
+        {category}
+      </Menu.Item>
+    );
+  });
+
   return (
-    <div>
-      Hello client categories!
-    </div>
+    <Menu pointing secondary textAlign='center'>
+      {/* <Menu.Item header>Categories</Menu.Item> */}
+      {categoriesList}
+    </Menu>
   )
 }
 

--- a/src/components/CategoryHeader.jsx
+++ b/src/components/CategoryHeader.jsx
@@ -28,7 +28,7 @@ const CategoryHeader = () => {
 
   return (
     <Menu pointing secondary data-cy="category-list">
-      <Menu.Item header>{t("categories")}</Menu.Item>
+      {/* <Menu.Item header>{t("categories")}</Menu.Item> */}
       {categoriesList}
     </Menu>
   );

--- a/src/components/CategoryHeader.jsx
+++ b/src/components/CategoryHeader.jsx
@@ -1,0 +1,11 @@
+import React from 'react'
+
+const CategoryHeader = () => {
+  return (
+    <div>
+      Hello client categories!
+    </div>
+  )
+}
+
+export default CategoryHeader

--- a/src/components/CategoryHeader.jsx
+++ b/src/components/CategoryHeader.jsx
@@ -1,18 +1,17 @@
-import React, { useState } from 'react'
+import React, { useState } from "react";
 import { useSelector } from "react-redux";
 import { Link } from "react-router-dom";
-import { Menu } from 'semantic-ui-react'
-
+import { Menu } from "semantic-ui-react";
 
 const CategoryHeader = () => {
   const { categories } = useSelector((state) => state);
-  const [activeItem, setActiveItem] = useState('business')
+  const [activeItem, setActiveItem] = useState("business");
 
   let categoriesList = categories.map((category, index) => {
     let categoryToLowerCase = category.toLowerCase();
     return (
       <Menu.Item
-        // data-cy={`${categoryToLowerCase}-category`}
+        data-cy={`${categoryToLowerCase}-category`}
         name={categoryToLowerCase}
         as={Link}
         to={{ pathname: `/category/${categoryToLowerCase}` }}
@@ -26,11 +25,10 @@ const CategoryHeader = () => {
   });
 
   return (
-    <Menu pointing secondary textAlign='center'>
-      {/* <Menu.Item header>Categories</Menu.Item> */}
+    <Menu pointing secondary data-cy="category-list">
       {categoriesList}
     </Menu>
-  )
-}
+  );
+};
 
-export default CategoryHeader
+export default CategoryHeader;

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Link } from "react-router-dom";
 import { useSelector } from "react-redux";
+import { useMediaQuery } from "react-responsive";
 import { Menu, Dropdown, Select } from "semantic-ui-react";
 import { useTranslation } from "react-i18next";
 import i18n from "../i18n";
@@ -8,6 +9,7 @@ import i18n from "../i18n";
 const Header = () => {
   const { categories } = useSelector((state) => state);
   const { t } = useTranslation();
+  const isTabletOrMobile = useMediaQuery({ query: "(max-width: 500px)" });
 
   let categoriesList = categories.map((category, index) => {
     let categoryToLowerCase = category.toLowerCase();
@@ -39,9 +41,9 @@ const Header = () => {
       >
         News In Progress
       </Menu.Item>
-      <Dropdown item text={t("categories")} data-cy="category-list">
+      {isTabletOrMobile && <Dropdown item text={t("categories")} data-cy="mobile-category-list">
         <Dropdown.Menu>{categoriesList}</Dropdown.Menu>
-      </Dropdown>
+      </Dropdown>}
       <Menu.Item position="right">
         <Select
           data-cy="language-selector"

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -41,13 +41,15 @@ const Header = () => {
       >
         News In Progress
       </Menu.Item>
-      {isTabletOrMobile && <Dropdown item text={t("categories")} data-cy="mobile-category-list">
-        <Dropdown.Menu>{categoriesList}</Dropdown.Menu>
-      </Dropdown>}
+      {isTabletOrMobile && (
+        <Dropdown item text={t("categories")} data-cy="mobile-category-list">
+          <Dropdown.Menu>{categoriesList}</Dropdown.Menu>
+        </Dropdown>
+      )}
       <Menu.Item position="right">
         <Select
           data-cy="language-selector"
-          placeholder="Choose Language"
+          placeholder={t("chooseLanguage")}
           options={languageOptions}
           onChange={(event, data) => {
             i18n.changeLanguage(data.value);

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -5,6 +5,7 @@ const en = {
       english: "English",
       swedish: "Swedish",
     },
+    chooseLanguage: "Choose Language"
   },
 };
 export default en;

--- a/src/locales/sv.js
+++ b/src/locales/sv.js
@@ -5,6 +5,7 @@ const sv = {
       english: "Engelska",
       swedish: "Svenska",
     },
+    chooseLanguage: "Välj Språk"
   },
 };
 export default sv;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4024,6 +4024,11 @@ css-loader@4.3.0:
     schema-utils "^2.7.1"
     semver "^7.3.2"
 
+css-mediaquery@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/css-mediaquery/-/css-mediaquery-0.1.2.tgz#6a2c37344928618631c54bd33cedd301da18bea0"
+  integrity sha1-aiw3NEkoYYYxxUvTPO3TAdoYvqA=
+
 css-prefers-color-scheme@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/css-prefers-color-scheme/-/css-prefers-color-scheme-3.1.1.tgz#6f830a2714199d4f0d0d0bb8a27916ed65cff1f4"
@@ -6217,6 +6222,11 @@ human-signals@^2.1.0:
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-2.1.0.tgz#dc91fcba42e4d06e4abaed33b3e7a3c02f514ea0"
   integrity sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==
 
+hyphenate-style-name@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/hyphenate-style-name/-/hyphenate-style-name-1.0.4.tgz#691879af8e220aea5750e8827db4ef62a54e361d"
+  integrity sha512-ygGZLjmXfPHj+ZWh6LwbC37l43MhfztxetbFCoYTM2VjkIUpeHgSNn7QIyVFj7YQ1Wl9Cbw5sholVJPzWvC2MQ==
+
 i18next@^21.3.2:
   version "21.3.2"
   resolved "https://registry.yarnpkg.com/i18next/-/i18next-21.3.2.tgz#8a83593e764fe19b81565737fbf78eed8a70ab00"
@@ -7812,6 +7822,13 @@ map-visit@^1.0.0:
   integrity sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=
   dependencies:
     object-visit "^1.0.0"
+
+matchmediaquery@^0.3.0:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/matchmediaquery/-/matchmediaquery-0.3.1.tgz#8247edc47e499ebb7c58f62a9ff9ccf5b815c6d7"
+  integrity sha512-Hlk20WQHRIm9EE9luN1kjRjYXAQToHOIAHPJn9buxBwuhfTHoKUcX+lXBbxc85DVQfXYbEQ4HcwQdd128E3qHQ==
+  dependencies:
+    css-mediaquery "^0.1.2"
 
 md5.js@^1.3.4:
   version "1.3.5"
@@ -9612,7 +9629,7 @@ prompts@^2.0.1:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
-prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -9835,13 +9852,6 @@ react-dev-utils@^11.0.3:
     strip-ansi "6.0.0"
     text-table "0.2.0"
 
-react-device-detect@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/react-device-detect/-/react-device-detect-2.1.1.tgz#e3a055a36be74d10a87a28182358209f701dbe6b"
-  integrity sha512-F0pYqYlo0/O5RmahZ1io3NHWd1ckr8THiiz/ItCW+ikh3TaKKCT2Rpk/NVKkSGnartzdkgOpcNKGDgO2JxdZvw==
-  dependencies:
-    ua-parser-js "0.7.28"
-
 react-dom@^17.0.2:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-17.0.2.tgz#ecffb6845e3ad8dbfcdc498f0d0a939736502c23"
@@ -9903,6 +9913,16 @@ react-refresh@^0.8.3:
   version "0.8.3"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.8.3.tgz#721d4657672d400c5e3c75d063c4a85fb2d5d68f"
   integrity sha512-X8jZHc7nCMjaCqoU+V2I0cOhNW+QMBwSUkeXnTi8IPe6zaRWfn60ZzvFDZqWPfmSJfjub7dDW1SP0jaHWLu/hg==
+
+react-responsive@^9.0.0-beta.4:
+  version "9.0.0-beta.4"
+  resolved "https://registry.yarnpkg.com/react-responsive/-/react-responsive-9.0.0-beta.4.tgz#90c1f1a4048971497ca9795068af6803eabc0ddb"
+  integrity sha512-jQSs5kIi38T39Ku98r8s75jM6JAaNEeVrHPHTrL2EYWuv8nusV3KRQcZZ4VlfwndIRedxmpb4T8FXA9ltlCFiw==
+  dependencies:
+    hyphenate-style-name "^1.0.0"
+    matchmediaquery "^0.3.0"
+    prop-types "^15.6.1"
+    shallow-equal "^1.2.1"
 
 react-router-dom@^5.3.0:
   version "5.3.0"
@@ -10696,6 +10716,11 @@ sha.js@^2.4.0, sha.js@^2.4.8:
   dependencies:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
+
+shallow-equal@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/shallow-equal/-/shallow-equal-1.2.1.tgz#4c16abfa56043aa20d050324efa68940b0da79da"
+  integrity sha512-S4vJDjHHMBaiZuT9NPb616CSmLf618jawtv3sufLl6ivK8WocjAo58cXwbRV1cgqxH0Qbv+iUt6m05eqEa2IRA==
 
 shallowequal@^1.1.0:
   version "1.1.0"
@@ -11701,11 +11726,6 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
-
-ua-parser-js@0.7.28:
-  version "0.7.28"
-  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.28.tgz#8ba04e653f35ce210239c64661685bf9121dec31"
-  integrity sha512-6Gurc1n//gjp9eQNXjD9O3M/sMwVtN5S8Lv9bvOYBfKfDNiIIhqiyi01vMBO45u4zkDE420w/e0se7Vs+sIg+g==
 
 unbox-primitive@^1.0.1:
   version "1.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9835,6 +9835,13 @@ react-dev-utils@^11.0.3:
     strip-ansi "6.0.0"
     text-table "0.2.0"
 
+react-device-detect@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/react-device-detect/-/react-device-detect-2.1.1.tgz#e3a055a36be74d10a87a28182358209f701dbe6b"
+  integrity sha512-F0pYqYlo0/O5RmahZ1io3NHWd1ckr8THiiz/ItCW+ikh3TaKKCT2Rpk/NVKkSGnartzdkgOpcNKGDgO2JxdZvw==
+  dependencies:
+    ua-parser-js "0.7.28"
+
 react-dom@^17.0.2:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-17.0.2.tgz#ecffb6845e3ad8dbfcdc498f0d0a939736502c23"
@@ -11694,6 +11701,11 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
+
+ua-parser-js@0.7.28:
+  version "0.7.28"
+  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.28.tgz#8ba04e653f35ce210239c64661685bf9121dec31"
+  integrity sha512-6Gurc1n//gjp9eQNXjD9O3M/sMwVtN5S8Lv9bvOYBfKfDNiIIhqiyi01vMBO45u4zkDE420w/e0se7Vs+sIg+g==
 
 unbox-primitive@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Link to PT: https://www.pivotaltracker.com/story/show/180009118

### User Story
```
As a user
In order to easily select the category of news I'd like to consume
I want the category list to render in a nice way depending on what platform I'm on
```

### Tasks
- Add test that sets `cy.viewport` to differentiate between mobile and desktop
- Add `react-responseive` dependency
- Use `react-responsive` hooks to check screen size
- In `App.jsx`, add inline if to either render `Category.jsx` or `CategoryMenu.jsx`

### Screenshots
![RtgRaAcf5Y](https://user-images.githubusercontent.com/31871856/138547737-9edf03d1-fc0e-402f-8e3a-5ad581284025.gif)
![image](https://user-images.githubusercontent.com/31871856/138547572-a0b4672c-1f86-419d-9318-0927ebd2c81b.png)
<img width="340" alt="Skärmavbild 2021-10-23 kl  09 47 19" src="https://user-images.githubusercontent.com/31871856/138547634-5057148a-9bde-4bd8-9574-811dd7d00b12.png">
