### PR TITLE
Only registered users can display full article

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -1,4 +1,6 @@
 {
   "baseUrl": "http://localhost:3000",
-  "chromeWebSecurity": false
+  "chromeWebSecurity": false,
+  "viewportWidth": 350,
+  "viewportHeight": 760
 }

--- a/cypress.json
+++ b/cypress.json
@@ -1,6 +1,4 @@
 {
   "baseUrl": "http://localhost:3000",
-  "chromeWebSecurity": false,
-  "viewportWidth": 350,
-  "viewportHeight": 760
+  "chromeWebSecurity": false
 }

--- a/cypress/integration/userCanReadAnArticle.feature.js
+++ b/cypress/integration/userCanReadAnArticle.feature.js
@@ -43,7 +43,7 @@ describe("User can read an article", () => {
   });
 
   describe("when the user in not signed in", () => {
-    it("is expected to display a paywall when not signed in", () => {
+    it("is expected to display a paywall", () => {
       cy.get("[data-cy=paywall]").within(() => {
         cy.get("[data-cy=register-button]").should("be.visible");
         cy.get("[data-cy=sign-in-button]").should("be.visible");

--- a/cypress/integration/userCanReadAnArticle.feature.js
+++ b/cypress/integration/userCanReadAnArticle.feature.js
@@ -14,6 +14,13 @@ describe("User can read an article", () => {
     cy.get("[data-cy=article-1]").click();
   });
 
+  it("is expected to display a paywall when not signed in", () => {
+    cy.get("[data-cy=paywall]").within(() => {
+      cy.get("[data-cy=register-button]").should("be.visible");
+      cy.get("[data-cy=sign-in-button]").should("be.visible");
+    });
+  });
+
   it("is expected to display the article", () => {
     cy.url().should("eq", "http://localhost:3000/articles/1");
     cy.get("[data-cy=displayed-article]").within(() => {

--- a/cypress/integration/userCanReadAnArticle.feature.js
+++ b/cypress/integration/userCanReadAnArticle.feature.js
@@ -14,14 +14,11 @@ describe("User can read an article", () => {
     cy.get("[data-cy=article-1]").click();
   });
 
-  it("is expected to display a paywall when not signed in", () => {
-    cy.get("[data-cy=paywall]").within(() => {
-      cy.get("[data-cy=register-button]").should("be.visible");
-      cy.get("[data-cy=sign-in-button]").should("be.visible");
-    });
-  });
-
   it("is expected to display the article", () => {
+    cy.window().its("store").invoke("dispatch", {
+      type: "SET_CURRENT_USER",
+      payload: true,
+    });
     cy.url().should("eq", "http://localhost:3000/articles/1");
     cy.get("[data-cy=displayed-article]").within(() => {
       cy.get("[data-cy=article-title]").should(
@@ -43,5 +40,14 @@ describe("User can read an article", () => {
   it("is expected to return to the home page when clicking home page button", () => {
     cy.get("[data-cy=home]").click();
     cy.url().should("eq", "http://localhost:3000/");
+  });
+
+  describe("when the user in not signed in", () => {
+    it("is expected to display a paywall when not signed in", () => {
+      cy.get("[data-cy=paywall]").within(() => {
+        cy.get("[data-cy=register-button]").should("be.visible");
+        cy.get("[data-cy=sign-in-button]").should("be.visible");
+      });
+    });
   });
 });

--- a/src/components/IndividualArticle.jsx
+++ b/src/components/IndividualArticle.jsx
@@ -18,13 +18,13 @@ const IndividualArticle = () => {
       <h3 data-cy="article-title">{article?.title}</h3>
       <p data-cy="article-authors">By: {article?.authors}</p>
       {!authenticated ? (
-        <div align="center">
+        <div>
           <Card fluid data-cy="paywall">
-            <h2>
+            <h2 align="center">
               To read this article please consider registering for an account
             </h2>
             <ul>
-              Benfits to registering:
+              <strong>Benefits to registering:</strong>
               <li>Full access to our unique, groundbreaking journalism.</li>
               <li>Read and write comments about the articles you love.</li>
             </ul>
@@ -32,7 +32,7 @@ const IndividualArticle = () => {
               Register Now
             </Button>
             <>
-              <div>Already signed up?</div>
+              <strong align="center">Already signed up?</strong>
               <Button data-cy="sign-in-button" color="orange">
                 Sign in
               </Button>

--- a/src/components/IndividualArticle.jsx
+++ b/src/components/IndividualArticle.jsx
@@ -1,11 +1,12 @@
 import React, { useEffect } from "react";
 import { useParams } from "react-router";
 import { useSelector } from "react-redux";
-import { Container } from "semantic-ui-react";
+import { Container, Button, Card } from "semantic-ui-react";
 import { Article } from "../modules/article";
 
 const IndividualArticle = () => {
   const { article } = useSelector((state) => state);
+  const { authenticated } = useSelector((state) => state);
   const { id } = useParams();
 
   useEffect(() => {
@@ -16,11 +17,37 @@ const IndividualArticle = () => {
     <Container text data-cy="displayed-article">
       <h3 data-cy="article-title">{article?.title}</h3>
       <p data-cy="article-authors">By: {article?.authors}</p>
-      <br />
-      <p data-cy="article-date">Published on: {article?.created_at}</p>
-      <div className="body" data-cy="article-body">
-        {article?.body}
-      </div>
+      {!authenticated ? (
+        <div align="center">
+          <Card fluid data-cy="paywall">
+            <h2>
+              To read this article please consider registering for an account
+            </h2>
+            <ul>
+              Benfits to registering:
+              <li>Full access to our unique, groundbreaking journalism.</li>
+              <li>Read and write comments about the articles you love.</li>
+            </ul>
+            <Button data-cy="register-button" color="orange">
+              Register Now
+            </Button>
+            <>
+              <div>Already signed up?</div>
+              <Button data-cy="sign-in-button" color="orange">
+                Sign in
+              </Button>
+            </>
+          </Card>
+        </div>
+      ) : (
+        <>
+          <br />
+          <p data-cy="article-date">Published on: {article?.created_at}</p>
+          <div className="body" data-cy="article-body">
+            {article?.body}
+          </div>
+        </>
+      )}
     </Container>
   );
 };

--- a/src/components/IndividualArticle.jsx
+++ b/src/components/IndividualArticle.jsx
@@ -31,12 +31,10 @@ const IndividualArticle = () => {
             <Button data-cy="register-button" color="orange">
               Register Now
             </Button>
-            <>
               <strong align="center">Already signed up?</strong>
               <Button data-cy="sign-in-button" color="orange">
                 Sign in
               </Button>
-            </>
           </Card>
         </div>
       ) : (

--- a/src/state/reducers/rootReducer.js
+++ b/src/state/reducers/rootReducer.js
@@ -1,10 +1,10 @@
 const rootReducer = (state, action) => {
   switch (action.type) {
-    case 'SET_CATEGORIES':
+    case "SET_CATEGORIES":
       return {
         ...state,
-        categories: action.payload
-      }
+        categories: action.payload,
+      };
     case "ERROR_MESSAGE":
       return {
         ...state,
@@ -21,6 +21,12 @@ const rootReducer = (state, action) => {
       return {
         ...state,
         article: action.payload,
+      };
+    case "SET_CURRENT-USER":
+      return {
+        ...state,
+        currentUser: action.payload,
+        authenticated: true,
       };
     default:
       return state;

--- a/src/state/reducers/rootReducer.js
+++ b/src/state/reducers/rootReducer.js
@@ -22,7 +22,7 @@ const rootReducer = (state, action) => {
         ...state,
         article: action.payload,
       };
-    case "SET_CURRENT-USER":
+    case "SET_CURRENT_USER":
       return {
         ...state,
         currentUser: action.payload,

--- a/src/state/store/initialState.js
+++ b/src/state/store/initialState.js
@@ -2,6 +2,7 @@ const initialState = {
   articles: [],
   article: null,
   categories: [],
+  authenticated: false,
 };
 
 export default initialState;

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -35,3 +35,7 @@ footer {
 footer p {
   color: #ccc;
 }
+
+ul {
+  list-style-type: none;
+}


### PR DESCRIPTION
PT Link: https://www.pivotaltracker.com/story/show/179938558

## User Story
As a news site
In order to display the full articles to only registered users
I want to restrict visitors from reading the articles

## Changes Proposed
- Create state for registered status in application state
- Add functionality to `rootReducer` and `configureStore` files
- Use `useSelector` on article page get authorised state
- Use ternary operator to prompt visitor to sign in

## Screenshots
![image](https://user-images.githubusercontent.com/26599559/138729273-c5839d2b-b11b-4f76-b660-9023cf5c67e3.png)
![image](https://user-images.githubusercontent.com/26599559/138731198-74f53d10-34a8-409b-961a-c5be6d8f3288.png)
